### PR TITLE
Explicitly set RedirectView.permanent to False.

### DIFF
--- a/dh5bp/urls.py
+++ b/dh5bp/urls.py
@@ -5,11 +5,15 @@ from django.views.generic import RedirectView, TemplateView
 
 urlpatterns = patterns('',
     url(r'^apple-touch-icon\.png$', RedirectView.as_view(
-        url='%simg/dh5bp/apple-touch-icon.png' % settings.STATIC_URL)),
+        url='%simg/dh5bp/apple-touch-icon.png' % settings.STATIC_URL,
+        permanent=False,
+    )),
     url(r'^crossdomain\.xml$', TemplateView.as_view(
         template_name='dh5bp/crossdomain.xml')),
     url(r'^favicon\.ico$', RedirectView.as_view(
-        url='%simg/dh5bp/favicon.ico' % settings.STATIC_URL)),
+        url='%simg/dh5bp/favicon.ico' % settings.STATIC_URL,
+        permanent=False,
+    )),
     url(r'^humans\.txt', TemplateView.as_view(
         template_name='dh5bp/humans.txt')),
     url(r'^robots\.txt', TemplateView.as_view(


### PR DESCRIPTION
Django 1.9 complains if "permanent" is unset:

RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
